### PR TITLE
Update to Version 1.0.3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,6 +261,9 @@ Two rows hold settings that are used for displaying the values when a user perfo
 
 ## _Versions_
 
+* 1.0.3
+	* Fix: Arrayformulas are no longer accepted as valid commands.
+	* Fix: Commands no longer overwrite arrayformulas.
 * 1.0.2
 	* Add an option to prevent the Bot from replying to invalid commands, or commands entered in the incorrect way (channel vs dm). See the "nocommandinchannel" and "nocommandindm" configuration settings for details.
 * 1.0.1

--- a/src/googleSheet.js
+++ b/src/googleSheet.js
@@ -82,9 +82,10 @@ async function loadGoogleSheet(reportError) {
 	commands = []
 	commandRows.forEach(row => {
 		if (row.command) {
-			commands[row.command] = row
+			commands.push(row)
 		}
 	})
+	console.log("Commands:", commands)
 
 	// Set the Output sheet.
 	if (!sheets[config.outputsheet]) {

--- a/src/googleSheet.js
+++ b/src/googleSheet.js
@@ -84,8 +84,7 @@ async function loadGoogleSheet(reportError) {
 		if (row.command) {
 			commands.push(row)
 		}
-	})
-	console.log("Commands:", commands)
+	}
 
 	// Set the Output sheet.
 	if (!sheets[config.outputsheet]) {

--- a/src/googleSheet.js
+++ b/src/googleSheet.js
@@ -84,7 +84,7 @@ async function loadGoogleSheet(reportError) {
 		if (row.command) {
 			commands.push(row)
 		}
-	}
+	})
 
 	// Set the Output sheet.
 	if (!sheets[config.outputsheet]) {

--- a/src/handleMessage.js
+++ b/src/handleMessage.js
@@ -52,7 +52,7 @@ async function handleMessage(msg) {
 	let parameter = content.substr(content.indexOf(" ") + 1).trim()
 
 	// Check if the command is an alias command.
-	let com = commands[command]
+	let com = commands.find(commandEntry => commandEntry.command === command)
 	if (com && com.type === "alias") {
 		if (!com.reference) {
 			msgError(msg, com, `Error: No reference set for alias command '${command}'.`)

--- a/src/handleMessage.js
+++ b/src/handleMessage.js
@@ -58,16 +58,17 @@ async function handleMessage(msg) {
 			msgError(msg, com, `Error: No reference set for alias command '${command}'.`)
 			return
 		}
-		if (!commands[com.reference]) {
+		const reference = commands.find(commandEntry => commandEntry.command === com.reference)
+		if (!reference) {
 			msgError(msg, com, `Error: Alias command '${command}' refers to an unknown command '${com.reference}'.`)
 			return
 		}
-		if (commands[com.reference].type === "alias") {
+		if (reference.type === "alias") {
 			msgError(msg, com, `Error: Alias command '${command}' refers to another alias command '${com.reference}'.`)
 			return
 		}
 		command = com.reference
-		com = commands[command]
+		com = reference
 	}
 
 	// Check if the command exists.


### PR DESCRIPTION
Update to Version 1.0.3:
* Fix an issue where arrayformula keywords such as "find" and "some" are recognized by the Bot:
	* Change commands to be stored without keys, to prevent them from overriding arrayformulas.
	* Change the check to find a command from checking the matching key to finding a command with a matching command property.